### PR TITLE
COURSES-675 Architect: duplicate resource declaration with classroom module and puppet_enterprise module

### DIFF
--- a/modules/classroom/manifests/master/student_environment.pp
+++ b/modules/classroom/manifests/master/student_environment.pp
@@ -13,7 +13,6 @@ class classroom::master::student_environment inherits classroom::params {
   }
 
   file { [
-    $environmentpath,
     "${environment}",
     "${environment}/manifests",
     "${environment}/modules",


### PR DESCRIPTION
This fix removes the management of the environment base directory from
the classroom module as it is already managed by the puppet_enterprise
module