### PR TITLE
Adds `--no-check-certificate` to wget

### DIFF
--- a/modules/student/manifests/init.pp
+++ b/modules/student/manifests/init.pp
@@ -15,7 +15,7 @@ class student {
 
   exec { 'Cache WordPress':
     cwd       => '/usr/src/wordpress',
-    command   => '/usr/bin/wget --no-clobber https://www.wordpress.org/wordpress-3.8.tar.gz',
+    command   => '/usr/bin/wget --no-clobber --no-check-certificate https://www.wordpress.org/wordpress-3.8.tar.gz',
     creates   => '/usr/src/wordpress/wordpress-3.8.tar.gz',
     logoutput => 'on_failure',
     user      => 'root',


### PR DESCRIPTION
Otherwise you get the following:

```
--2015-01-13 20:08:11--  https://www.wordpress.org/wordpress-3.8.tar.gz
Resolving www.wordpress.org... 66.155.40.250, 66.155.40.249
Connecting to www.wordpress.org|66.155.40.250|:443... connected.
HTTP request sent, awaiting response... 301 Moved Permanently
Location: https://wordpress.org/wordpress-3.8.tar.gz [following]
--2015-01-13 20:08:11--  https://wordpress.org/wordpress-3.8.tar.gz
Resolving wordpress.org... 66.155.40.249, 66.155.40.250
Connecting to wordpress.org|66.155.40.249|:443... connected.
ERROR: certificate common name “*.wordpress.org” doesn’t match requested host name “wordpress.org”.
To connect to wordpress.org insecurely, use ‘--no-check-certificate’.
```