### PR TITLE
Bootstrap repos

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -89,12 +89,18 @@ task :build do
  system('RUBYLIB="/usr/src/puppet/lib:/usr/src/facter/lib:/usr/src/hiera/lib" /usr/src/puppet/bin/puppet apply --modulepath=/usr/src/puppetlabs-training-bootstrap/modules --verbose /usr/src/puppetlabs-training-bootstrap/manifests/site.pp')
 end
 
+desc "Post build cleanup tasks"
+task :post do
+  system('RUBYLIB="/usr/src/puppet/lib:/usr/src/facter/lib:/usr/src/hiera/lib" /usr/src/puppet/bin/puppet apply --modulepath=/usr/src/puppetlabs-training-bootstrap/modules --verbose /usr/src/puppetlabs-training-bootstrap/manifests/post.pp')
+end
+
 desc "Full Training VM Build"
 task :training do
   cputs "Building Training VM"
   Rake::Task["standalone_puppet"].execute
   Rake::Task["training_pre"].execute
   Rake::Task["build"].execute
+  Rake::Task["post"].execute
 end
 
 desc "Full Learning VM Build"
@@ -103,6 +109,7 @@ task :learning do
   Rake::Task["standalone_puppet"].execute
   Rake::Task["learning_pre"].execute
   Rake::Task["build"].execute
+  Rake::Task["post"].execute
 end
 
 desc "Full Student VM Build"
@@ -111,6 +118,7 @@ task :student do
   Rake::Task["standalone_puppet"].execute
   Rake::Task["student_pre"].execute
   Rake::Task["build"].execute
+  Rake::Task["post"].execute
 end
 
 def download(url,path)

--- a/manifests/post.pp
+++ b/manifests/post.pp
@@ -1,0 +1,8 @@
+# Manifest for post build cleanup
+
+# Disable non-local yum repos
+yumrepo { [ 'updates', 'base', 'extras', 'epel']:
+  enabled  => '0',
+  priority => '99',
+  skip_if_unavailable => '1',
+}

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -5,13 +5,14 @@ node default {
     group => 'root',
   }
   class { 'bootstrap::get_pe': version => '3.7.2' }
-  class { 'epel': epel_enabled => false }
+  include epel
   include bootstrap
   include localrepo
   include training
 }
 
 node /student/ {
+  include epel
   class { 'student': } 
 }
 

--- a/modules/bootstrap/manifests/init.pp
+++ b/modules/bootstrap/manifests/init.pp
@@ -34,6 +34,10 @@ class bootstrap ($print_console_login = false) {
     priority => '99',
     skip_if_unavailable => '1',
   }
+  # Include epel but leave it disabled.
+  class { 'epel':
+    epel_enabled = '0',
+  }
 
   # Moving the root user declaration to the userprefs module.
   # user { 'root':

--- a/modules/bootstrap/manifests/init.pp
+++ b/modules/bootstrap/manifests/init.pp
@@ -29,16 +29,17 @@ class bootstrap ($print_console_login = false) {
     ],
     require => Package['yum-plugin-priorities'],
   }
-  yumrepo { [ 'updates', 'base', 'extras']:
-    enabled  => '0',
-    priority => '99',
-    skip_if_unavailable => '1',
-  }
-  # Include epel but leave it disabled.
-  class { 'epel':
-    epel_enabled => '0',
-    before => Class['localrepo'],
-  }
+  #  yumrepo { [ 'updates', 'base', 'extras']:
+  #  enabled  => '0',
+  #  priority => '99',
+  #  skip_if_unavailable => '1',
+  #}
+  ## Include epel but leave it disabled.
+  #class { 'epel':
+  #  epel_enabled => '0',
+  #  before => Class['localrepo'],
+  #}
+  include epel
 
   # Moving the root user declaration to the userprefs module.
   # user { 'root':

--- a/modules/bootstrap/manifests/init.pp
+++ b/modules/bootstrap/manifests/init.pp
@@ -36,7 +36,7 @@ class bootstrap ($print_console_login = false) {
   }
   # Include epel but leave it disabled.
   class { 'epel':
-    epel_enabled = '0',
+    epel_enabled => '0',
   }
 
   # Moving the root user declaration to the userprefs module.

--- a/modules/bootstrap/manifests/init.pp
+++ b/modules/bootstrap/manifests/init.pp
@@ -37,6 +37,7 @@ class bootstrap ($print_console_login = false) {
   # Include epel but leave it disabled.
   class { 'epel':
     epel_enabled => '0',
+    before => Class['localrepo'],
   }
 
   # Moving the root user declaration to the userprefs module.

--- a/modules/classroom/manifests/repositories.pp
+++ b/modules/classroom/manifests/repositories.pp
@@ -13,7 +13,7 @@ class classroom::repositories (
       },
     }
     # Don't choke if another module has "include epel"
-    if ! defined Class['epel'] {
+    if ! defined(Class['epel']) {
       class { 'epel':
         epel_enabled => $offline,
       }

--- a/modules/classroom/manifests/repositories.pp
+++ b/modules/classroom/manifests/repositories.pp
@@ -12,6 +12,12 @@ class classroom::repositories (
         false => '1',
       },
     }
+    # Don't choke if another module has "include epel"
+    if ! defined Class['epel'] {
+      class { 'epel':
+        epel_enabled => $offline,
+      }
+    }
   }
 
 }

--- a/modules/student/manifests/init.pp
+++ b/modules/student/manifests/init.pp
@@ -150,5 +150,4 @@ class student {
   # create local repos
   include localrepo
 
-  include epel
 }


### PR DESCRIPTION
This moves the yumrepo offline classification to a second puppet manifest that's run after the initial VM bootstrap.