### PR TITLE
underscores are illegal and break several things

### DIFF
--- a/scripts/classroom/setup_classroom.sh
+++ b/scripts/classroom/setup_classroom.sh
@@ -31,7 +31,7 @@ function validate_name
 {
   name="$1"
 
-  [[ "${name}" =~ ^[a-z0-9][a-z0-9_]{2,}$ &&
+  [[ "${name}" =~ ^[a-z0-9][a-z0-9]{2,}$ &&
      "${name}" =~ [a-z]+               &&
      "${name}" != "root"               &&
      "${name}" != "master" ]]


### PR DESCRIPTION
Underscores cause the classroom module to create broken environments, and are not legal characters in domain names anyway. This change just removes the underscore from the name validation regex. The regex could probably be further improved in other ways, but this will at least catch one case we know to break things.