### PR TITLE
Cleaning up some files in /root

### DIFF
--- a/manifests/post.pp
+++ b/manifests/post.pp
@@ -6,3 +6,14 @@ yumrepo { [ 'updates', 'base', 'extras', 'epel']:
   priority => '99',
   skip_if_unavailable => '1',
 }
+
+# Delete cruft left by install process
+file { [
+        '/root/install.log',
+        '/root/install.log.syslog',
+        'linux.iso',
+        'post.log',
+        'anaconda-ks.cfg'
+       ]:
+  ensure => absent,
+}


### PR DESCRIPTION
I'm going to move all of the post-build cleanup scripts to this manifest so that we're less dependent on bash scripts.