### PR TITLE
Create environment directory

### DIFF
--- a/scripts/classroom/setup_classroom.sh
+++ b/scripts/classroom/setup_classroom.sh
@@ -143,6 +143,9 @@ then
 
   [ $? -ne 0 ] && ((++ERRORCOUNT))
 
+  # create environments directory so we can populate it later
+  mkdir -p /etc/puppetlabs/puppet/environments
+
   # snapshot $ssldir for engineering debug purposes
   snapshot.sh ssldir
 fi


### PR DESCRIPTION
The simplified installer doesn't make this directory, but in Architect,
we need it to exist so we can populate it with a starting environment.
This uses `-p` so it becomes a noop in the case that the installer changes
to include the directory at some point.

Fixes #TRAINVM-194