### PR TITLE
Skytap Automation tools update

### DIFF
--- a/cloud/virtual/skytap/virtualclassroom.rb
+++ b/cloud/virtual/skytap/virtualclassroom.rb
@@ -24,7 +24,8 @@ end
 def create_base_environment(name, base_template)
   env_config = {
     'template_id' => base_template, 
-    'name' => name 
+    'name' => name,
+    'suspend_on_idle' => 3600
   }
   return JSON.parse(RestClient.post(CONFIGURATION_URL, JSON.generate(env_config), HEADERS))
 end
@@ -88,6 +89,7 @@ environment = add_student_vms(environment['id'],classroom['students'],classroom[
 # Configure student machines hostnames, names, and mapped ports
 student_vms = []
 all_vms = []
+view_vms = []
 students = classroom['students']
 environment['vms'].each do |vm|
   if vm['id'] != master_vm_id then
@@ -96,6 +98,9 @@ environment['vms'].each do |vm|
     map_vm_ports(vm,classroom['student_ports'])
     # Add only Student VMs to student publish set
     student_vms.push( { 'vm_ref' => URL + 'vms/' + vm['id'], 'access' => 'use' } )
+
+    # Add students to the View Only publish set
+    #view_vms.push( { 'vm_ref' => URL + 'vms/' + vm['id'], 'access' => 'view_only' } )
   else
     set_vm_name(vm,classroom['master_name'])
     map_vm_ports(vm,classroom['master_ports'])
@@ -105,6 +110,7 @@ environment['vms'].each do |vm|
 end
 
 # Create published sets for classroom evironment
+#publish_view_vms = create_publish_set( environment['id'], all_vms, 'View Only' )
 publish_student_vms = create_publish_set( environment['id'], student_vms, 'Student VMs' )
 publish_all_vms = create_publish_set( environment['id'], all_vms, 'Instructor Dashboard' )
 

--- a/cloud/virtual/skytap/windows.yaml
+++ b/cloud/virtual/skytap/windows.yaml
@@ -1,6 +1,6 @@
 ---
 title: Windows Esstentials Apr23
-master_template_id: 554849 
+master_template_id: 596249
 master_name: master
 master_ports:
   - 22
@@ -12,10 +12,4 @@ student_vm_id:
 student_ports:
   - 80
 students:
-  - christianp
-  - adams
-  - paulf
-  - paulc
-  - iano
-  - toms
   - carthik

--- a/cloud/virtual/skytap/windows.yaml
+++ b/cloud/virtual/skytap/windows.yaml
@@ -1,5 +1,5 @@
 ---
-title: Windows Esstentials Apr23
+title: Windows Esstentials Test
 master_template_id: 596249
 master_name: master
 master_ports:


### PR DESCRIPTION
The lines about adding a "view_only" url are commented out because Skytap throws a 409 error.  I suspect that their API has changed and that "view_only" isn't valid anymore, but that's what the documentation says to use.  I'm going to file a ticket to find out how to get it working.