### PR TITLE
Add metrics scripts to the VM

### DIFF
--- a/scripts/classroom/metrics/list_all_metrics.rb
+++ b/scripts/classroom/metrics/list_all_metrics.rb
@@ -1,0 +1,17 @@
+#!/usr/bin/env ruby
+
+require 'jmx'
+
+client = JMX.connect(:host => ARGV.first, :port => ARGV.last)
+
+#memory = client["java.lang:type=Memory"]
+#puts memory.attributes
+
+metric_names = client.query_names
+metric_names.each do |metric_name|
+   puts "Metric Name Class: #{metric_name.class}"
+   puts "Metric Name toString: #{metric_name}"
+   puts "Metric Domain: #{metric_name.domain}"
+   puts "Metric Properties: #{metric_name.key_property_list_string}"
+   puts
+end

--- a/scripts/classroom/metrics/list_all_puppet_metrics.rb
+++ b/scripts/classroom/metrics/list_all_puppet_metrics.rb
@@ -1,0 +1,18 @@
+#!/usr/bin/env ruby
+
+require 'jmx'
+
+client = JMX.connect(:host => ARGV.first, :port => ARGV.last)
+
+metric_names = client.query_names("metrics:*")
+metric_names.each do |metric_name|
+   name_property = metric_name.get_key_property("name").sub(/^"/, "").sub(/"$/, "")
+   if name_property.start_with?("puppetlabs.")
+      puts name_property
+      mbean = client[metric_name]
+      mbean.attributes.each do |attribute|
+         puts "\t#{attribute}: #{mbean[attribute]}"
+      end
+      puts
+   end
+end

--- a/scripts/classroom/metrics/puppet_function_stats.rb
+++ b/scripts/classroom/metrics/puppet_function_stats.rb
@@ -12,7 +12,7 @@ metric_names.each do |metric_name|
    if match = name_property.match(/^puppetlabs\..*functions\.(.*)$/)
       mbean = client[metric_name]
       fname = match[1]
-      mean = mbean["Mean"]
+      mean = mbean["Mean"].nan? ? 0 : mbean["Mean"]
       count = mbean["Count"]
       functions << {:name => fname,
                     :mean => mean.round(2),

--- a/scripts/classroom/metrics/puppet_function_stats.rb
+++ b/scripts/classroom/metrics/puppet_function_stats.rb
@@ -1,0 +1,32 @@
+#!/usr/bin/env ruby
+
+require 'jmx'
+require 'table_print'
+
+client = JMX.connect(:host => ARGV.first, :port => ARGV.last)
+
+metric_names = client.query_names("metrics:*")
+functions = []
+metric_names.each do |metric_name|
+   name_property = metric_name.get_key_property("name").sub(/^"/, "").sub(/"$/, "")
+   if match = name_property.match(/^puppetlabs\..*functions\.(.*)$/)
+      mbean = client[metric_name]
+      fname = match[1]
+      mean = mbean["Mean"]
+      count = mbean["Count"]
+      functions << {:name => fname,
+                    :mean => mean.round(2),
+                    :count => count,
+                    :aggregate => (mean * count).round(2)}
+   end
+end
+
+sorted_functions = functions.sort_by { |v| - v[:aggregate] }
+
+puts
+puts "Function calls, sorted by total CPU time spent (in ms)"
+puts
+
+tp sorted_functions, :name, :aggregate, :count, :mean
+
+puts

--- a/scripts/classroom/metrics/puppet_http_stats.rb
+++ b/scripts/classroom/metrics/puppet_http_stats.rb
@@ -32,7 +32,7 @@ end
 
 def request_count_info(request_type)
    mbean = metric("http.#{canonical(request_type)}-requests")
-   mean = mbean["Mean"]
+   mean = mbean["Mean"].nan? ? 0 : mbean["Mean"]
    count = mbean["Count"]
    {:name => request_type,
     :mean => mean.round(2),

--- a/scripts/classroom/metrics/puppet_http_stats.rb
+++ b/scripts/classroom/metrics/puppet_http_stats.rb
@@ -1,0 +1,84 @@
+#!/usr/bin/env ruby
+
+require 'jmx'
+require 'table_print'
+
+MetricsId = ARGV.first.gsub(".#{`facter domain`.chomp}", '')
+
+def client
+   @client ||= JMX.connect(:host => ARGV.first, :port => ARGV.last)
+
+end
+
+def metric_name(name)
+  if name =~ /\A[\w.-]+\z/
+    "metrics:name=puppetlabs.#{MetricsId}.#{name}"
+  else
+    "metrics:name=\"puppetlabs.#{MetricsId}.#{name}\""
+  end
+end
+
+def metric(name)
+   client[metric_name(name)]
+end
+
+def canonical(name)
+  if ['total', 'other', 'active' ].include? name
+    name
+  else
+    "puppet-v3-#{name}-/\\*/"
+  end
+end
+
+def request_count_info(request_type)
+   mbean = metric("http.#{canonical(request_type)}-requests")
+   mean = mbean["Mean"]
+   count = mbean["Count"]
+   {:name => request_type,
+    :mean => mean.round(2),
+    :count => count,
+    :aggregate => (mean * count).round(2)}
+end
+
+def request_info(request_type, total)
+   req_count_info = request_count_info(request_type)
+   perc_count = (metric("http.#{canonical(request_type)}-percentage")["Value"] * 100).round(2)
+   perc_time = ((req_count_info[:aggregate] / total[:aggregate]) * 100).round(2)
+   req_count_info[:perc_count] = perc_count
+   req_count_info[:perc_time] = perc_time
+   req_count_info
+end
+
+puts
+
+num_cpus = metric("num-cpus")["Value"]
+active = metric("http.active-requests")["Count"]
+active_histo = metric("http.active-histo")
+
+puts "Active Request Statistics"
+puts "------------------------------------"
+puts "Num CPUs: #{num_cpus}"
+puts "Current Active Requests: #{active}"
+puts "Average Num Active Requests: #{active_histo["Mean"]}"
+puts
+
+total = request_count_info("total")
+total[:perc_count] = 100
+total[:perc_time] = 100
+request_counts = []
+request_counts << total
+request_counts << request_info("catalog", total)
+request_counts << request_info("node", total)
+request_counts << request_info("report", total)
+request_counts << request_info("other", total)
+request_counts << request_info("file_metadatas", total)
+request_counts << request_info("file_metadata", total)
+request_counts << request_info("file_content", total)
+
+puts "Request Statistics (time spent in ms; percentage of total requests, etc.)"
+puts
+
+ratios = request_counts.sort_by { |r| - r[:aggregate] }
+tp ratios, :name, :aggregate, :count, :mean, :perc_count, :perc_time
+
+puts

--- a/scripts/classroom/metrics/puppet_resource_eval_stats.rb
+++ b/scripts/classroom/metrics/puppet_resource_eval_stats.rb
@@ -1,0 +1,33 @@
+#!/usr/bin/env ruby
+
+require 'jmx'
+require 'table_print'
+
+client = JMX.connect(:host => ARGV.first, :port => ARGV.last)
+
+metric_names = client.query_names("metrics:*")
+resources = []
+metric_names.each do |metric_name|
+   name_property = metric_name.get_key_property("name").sub(/^"/, "").sub(/"$/, "")
+   if match = name_property.match(/^puppetlabs\..*compiler.evaluate_resource\.(.*)$/)
+      mbean = client[metric_name]
+      rname = match[1]
+      mean = mbean["Mean"]
+      count = mbean["Count"]
+      resources << {:name => rname,
+                    :mean => mean.round(2),
+                    :count => count,
+                    :aggregate => (mean * count).round(2)}
+   end
+end
+
+sorted_resources = resources.sort_by { |v| - v[:aggregate] }
+
+puts
+puts "Resource evaluations during compile, sorted by total CPU time spent (in ms)"
+puts
+
+tp.set :max_width, 60
+tp sorted_resources, :name, :aggregate, :count, :mean
+
+puts

--- a/scripts/classroom/metrics/puppet_resource_eval_stats.rb
+++ b/scripts/classroom/metrics/puppet_resource_eval_stats.rb
@@ -12,7 +12,7 @@ metric_names.each do |metric_name|
    if match = name_property.match(/^puppetlabs\..*compiler.evaluate_resource\.(.*)$/)
       mbean = client[metric_name]
       rname = match[1]
-      mean = mbean["Mean"]
+      mean = mbean["Mean"].nan? ? 0 : mbean["Mean"]
       count = mbean["Count"]
       resources << {:name => rname,
                     :mean => mean.round(2),

--- a/scripts/classroom/puppetserver_metrics
+++ b/scripts/classroom/puppetserver_metrics
@@ -1,19 +1,28 @@
 #! /bin/sh
 
-METRIC=$(basename $1 .rb) # strip the extension, just in case
 PORT='9010'
 SCRIPTS='/usr/local/bin/metrics'
 JAVA='/opt/puppetlabs/server/bin/java'
 GEM_HOME='/opt/puppetlabs/server/data/puppetserver/jruby-gems'
 CLASSPATH='/opt/puppetlabs/server/apps/puppetserver/puppet-server-release.jar org.jruby.Main'
-SERVER=$(puppet master --configprint server)
+
+while getopts ":l" opt; do
+  case $opt in
+    l)
+      SERVER=$(facter fqdn)
+      ;;
+  esac
+done
+shift $((OPTIND - 1))
 
 if [ "$#" -ne 1 ]
 then
-  echo "Usage: $0 <name of metric to display>"
+  echo "Usage: $0 [-l] <name of metric to display>"
   echo
   echo "Collect and display metrics from a running Puppet Master."
   echo "This requires an unauthenticated JMX remote listening on port ${PORT}."
+  echo
+  echo "Pass -l to run against your local server. Defaults to classroom master."
   echo
   echo "Available metrics:"
   for i in ${SCRIPTS}/*; do echo -e "\t* $(basename $i .rb)"; done
@@ -21,5 +30,13 @@ then
   exit 1
 fi
 
-export GEM_HOME
-exec ${JAVA} -cp ${CLASSPATH} ${SCRIPTS}/${METRIC}.rb ${SERVER} ${PORT}
+METRIC=$(basename $1 .rb) # strip the extension, just in case
+[[ $SERVER ]] || SERVER=$(puppet master --configprint server)
+
+if [ -f "${JAVA}" ]; then
+  export GEM_HOME
+  exec ${JAVA} -cp ${CLASSPATH} ${SCRIPTS}/${METRIC}.rb ${SERVER} ${PORT}
+else
+  # run directly. Untested.
+  exec ${SCRIPTS}/${METRIC}.rb ${SERVER} ${PORT}
+fi

--- a/scripts/classroom/puppetserver_metrics
+++ b/scripts/classroom/puppetserver_metrics
@@ -1,0 +1,25 @@
+#! /bin/sh
+
+METRIC=$(basename $1 .rb) # strip the extension, just in case
+PORT='9010'
+SCRIPTS='/usr/local/bin/metrics'
+JAVA='/opt/puppetlabs/server/bin/java'
+GEM_HOME='/opt/puppetlabs/server/data/puppetserver/jruby-gems'
+CLASSPATH='/opt/puppetlabs/server/apps/puppetserver/puppet-server-release.jar org.jruby.Main'
+SERVER=$(puppet master --configprint server)
+
+if [ "$#" -ne 1 ]
+then
+  echo "Usage: $0 <name of metric to display>"
+  echo
+  echo "Collect and display metrics from a running Puppet Master."
+  echo "This requires an unauthenticated JMX remote listening on port ${PORT}."
+  echo
+  echo "Available metrics:"
+  for i in ${SCRIPTS}/*; do echo -e "\t* $(basename $i .rb)"; done
+  echo
+  exit 1
+fi
+
+export GEM_HOME
+exec ${JAVA} -cp ${CLASSPATH} ${SCRIPTS}/${METRIC}.rb ${SERVER} ${PORT}


### PR DESCRIPTION
This requires setting java_args as described by

https://confluence.puppetlabs.com/display/PROD/Metrics+and+Profiling+Data

Usage: /usr/local/bin/puppetserver_metrics [name of metric to display]

Collect and display metrics from a running Puppet Master.
This requires an unauthenticated JMX remote listening on port 9010.

Available metrics:
  * list_all_metrics
  * list_all_puppet_metrics
  * puppet_function_stats
  * puppet_http_stats
  * puppet_resource_eval_stats