### PR TITLE
Use RVM on Centos6 vms

### DIFF
--- a/packer/scripts/student_build.sh
+++ b/packer/scripts/student_build.sh
@@ -1,9 +1,12 @@
+yum -y install augeas-devel
+
 # Install new ruby
 sudo gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
 curl -sSL https://get.rvm.io | sudo bash -s stable --ruby=1.9.3
 
 source /etc/profile.d/rvm.sh
 rvm install 1.9.3-dev
+gem install ruby-augeas
 
 cd /usr/src/
 

--- a/packer/scripts/student_build.sh
+++ b/packer/scripts/student_build.sh
@@ -1,4 +1,12 @@
+# Install new ruby
+sudo gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
+curl -sSL https://get.rvm.io | sudo bash -s stable --ruby=1.9.3
+
+source /etc/profile.d/rvm.sh
+rvm install 1.9.3-dev
+
 cd /usr/src/
+
 git clone https://github.com/puppetlabs/puppetlabs-training-bootstrap
 cd /usr/src/puppetlabs-training-bootstrap/
 

--- a/packer/scripts/training_build.sh
+++ b/packer/scripts/training_build.sh
@@ -1,9 +1,12 @@
+yum -y install augeas-devel
+
 # Install new ruby
 sudo gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
 curl -sSL https://get.rvm.io | sudo bash -s stable --ruby=1.9.3
 
 source /etc/profile.d/rvm.sh
 rvm install 1.9.3-dev
+gem install ruby-augeas
 
 cd /usr/src/
 

--- a/packer/scripts/training_build.sh
+++ b/packer/scripts/training_build.sh
@@ -1,4 +1,9 @@
+# Install new ruby
+sudo gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
+curl -sSL https://get.rvm.io | sudo bash -s stable --ruby=1.9.3
+
 source /etc/profile.d/rvm.sh
+rvm install 1.9.3-dev
 
 cd /usr/src/
 


### PR DESCRIPTION
Centos6 ships with a really old version of ruby, which is starting to cause issues.  This updates to a newer version using RVM and will let us use other versions as needed.