### PR TITLE
Centos user and authorized key for non-aws builds

### DIFF
--- a/packer/educationbuild.json
+++ b/packer/educationbuild.json
@@ -43,6 +43,7 @@
       ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -E -S bash '{{.Path}}'",
       "scripts": [
+        "scripts/ssh_user.sh",
         "scripts/vagrant.sh",
         "scripts/{{user `vm_type`}}_build.sh",
         "scripts/cleanup.sh",

--- a/packer/scripts/ssh_user.sh
+++ b/packer/scripts/ssh_user.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# If the centos user doesn't exsit, add the insecure vagrant public key
+# and add the user to the sudoers group
+# This is horribly insecure, don't ever use this on a production machine
+
+if ! grep centos /etc/passwd
+then
+  adduser centos
+  echo "centos  ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+  mkdir -p /home/centos/.ssh/
+  curl https://raw.githubusercontent.com/mitchellh/vagrant/master/keys/vagrant.pub >> /home/centos/.ssh/authorized_keys
+  chown -R centos:centos /home/centos/.ssh/
+  chmod 0600 /home/centos/.ssh/authorized_keys
+fi


### PR DESCRIPTION
Since some VMs will be in AWS, this will let us standardize on using the `centos` user for connecting to VMs.

For classroom use, instructors can just use the vagrant private key.
For online courses, this script isn't run so they will provide a keypair at launch time in EC2.