### PR TITLE
Change method to determine OS release

### DIFF
--- a/packer/scripts/cleanup.sh
+++ b/packer/scripts/cleanup.sh
@@ -1,5 +1,5 @@
 # Make sure udev doesn't block our network
-if grep -q -i "release 6" /etc/redhat-release ; then
+if uname -r | grep -q el6 ; then
     sudo rm -rf /etc/udev/rules.d/70-persistent-net.rules
     sudo rm -rf /lib/udev/rules.d/75-persistent-net-generator.rules
 fi


### PR DESCRIPTION
/etc/redhat-release is an easily modified and sometimes modified with file, because of older applications my company does modify this file.

It is arguable but one should not assume /etc/redhat-release is correct, only sure fire way is to look at uname output.
This method is reusable on RHEL7 as well where the contents of redhat-release change, just in case we have to update udev on RHEL7.

I tested on:
CentOS 6.5 and RHEL 6.5