### PR TITLE
Simplify bootstrap

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -16,12 +16,10 @@ moduledir './modules/'
 
 
 mod 'bootstrap', 
-  :git => 'https://github.com/samuelson/pltraining-bootstrap',
-  :ref => 'simplify_bootstrap'
+  :git => 'https://github.com/puppetlabs/pltraining-bootstrap'
 
 mod 'learning',
-  :git => 'https://github.com/samuelson/pltraining-learning',
-  :ref => 'simplify_bootstrap'
+  :git => 'https://github.com/puppetlabs/pltraining-learning'
 
 mod 'lms',
   :git => 'https://github.com/puppetlabs/pltraining-lms'

--- a/Puppetfile
+++ b/Puppetfile
@@ -16,10 +16,12 @@ moduledir './modules/'
 
 
 mod 'bootstrap', 
-  :git => 'https://github.com/puppetlabs/pltraining-bootstrap'
+  :git => 'https://github.com/samuelson/pltraining-bootstrap',
+  :ref => 'simplify_bootstrap'
 
 mod 'learning',
-  :git => 'https://github.com/puppetlabs/pltraining-learning'
+  :git => 'https://github.com/samuelson/pltraining-learning',
+  :ref => 'simplify_bootstrap'
 
 mod 'lms',
   :git => 'https://github.com/puppetlabs/pltraining-lms'

--- a/Rakefile
+++ b/Rakefile
@@ -155,15 +155,15 @@ task :lms_pre do
 end
 
 desc "Apply bootstrap manifest"
-task :build do
+task :build [:arg1] do |role|
  cputs "Installing R10k"
  system('PATH=$PATH:/opt/puppetlabs/puppet/bin:/usr/local/bin gem install r10k -v 1.5.1 --no-RI --no-RDOC')
  Dir.chdir('/usr/src/puppetlabs-training-bootstrap') do
   cputs "Running r10k Puppetfile install"
   system('PATH=$PATH:/opt/puppetlabs/puppet/bin:/usr/local/bin r10k puppetfile install')
  end
- cputs "Running puppet apply on site.pp"
- system('PATH=$PATH:/opt/puppetlabs/puppet/bin puppet apply --modulepath=/usr/src/puppetlabs-training-bootstrap/modules:/opt/puppetlabs/puppet/modules --verbose /usr/src/puppetlabs-training-bootstrap/manifests/site.pp')
+ cputs "Running puppet apply on #{role}.pp"
+ system("PATH=$PATH:/opt/puppetlabs/puppet/bin puppet apply --modulepath=/usr/src/puppetlabs-training-bootstrap/modules:/opt/puppetlabs/puppet/modules --verbose /usr/src/puppetlabs-training-bootstrap/manifests/#{role}.pp")
 end
 
 desc "Post build cleanup tasks"
@@ -192,16 +192,14 @@ task :training do
   cputs "Building Training VM"
   Rake::Task["standalone_puppet_agent"].execute
   Rake::Task["training_pre"].execute
-  Rake::Task["build"].execute
+  Rake::Task["build"].invoke("training")
   Rake::Task["post"].execute
 end
 
 desc "Full Learning VM Build"
 task :learning do
   cputs "Building Learning VM"
-  Rake::Task["learning_pre"].execute
-  Rake::Task["install_pe"].execute
-  Rake::Task["build"].execute
+  Rake::Task["build"].invoke("learning")
   Rake::Task["post"].execute
 end
 
@@ -210,7 +208,7 @@ task :student do
   cputs "Building Student VM"
   Rake::Task["standalone_puppet_agent"].execute
   Rake::Task["student_pre"].execute
-  Rake::Task["build"].execute
+  Rake::Task["build"].invoke("student")
   Rake::Task["post"].execute
 end
 
@@ -219,7 +217,7 @@ task :master do
   cputs "Building Master VM"
   Rake::Task["master_pre"].execute
   Rake::Task["install_pe"].execute
-  Rake::Task["build"].execute
+  Rake::Task["build"].invoke("master")
   Rake::Task["post"].execute
 end
 
@@ -228,7 +226,7 @@ task :lms do
   cputs "Building LMS VM"
   Rake::Task["standalone_puppet_agent"].execute
   Rake::Task["lms_pre"].execute
-  Rake::Task["build"].execute
+  Rake::Task["build"].invoke("lms")
   Rake::Task["post"].execute
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -155,15 +155,15 @@ task :lms_pre do
 end
 
 desc "Apply bootstrap manifest"
-task :build, [:arg1] do |role|
+task :build, [:role] do |t,args|
  cputs "Installing R10k"
  system('PATH=$PATH:/opt/puppetlabs/puppet/bin:/usr/local/bin gem install r10k -v 1.5.1 --no-RI --no-RDOC')
  Dir.chdir('/usr/src/puppetlabs-training-bootstrap') do
   cputs "Running r10k Puppetfile install"
   system('PATH=$PATH:/opt/puppetlabs/puppet/bin:/usr/local/bin r10k puppetfile install')
  end
- cputs "Running puppet apply on #{role}.pp"
- system("PATH=$PATH:/opt/puppetlabs/puppet/bin puppet apply --modulepath=/usr/src/puppetlabs-training-bootstrap/modules:/opt/puppetlabs/puppet/modules --verbose /usr/src/puppetlabs-training-bootstrap/manifests/#{role}.pp")
+ cputs "Running puppet apply on #{args{:role}}.pp"
+ system("PATH=$PATH:/opt/puppetlabs/puppet/bin puppet apply --modulepath=/usr/src/puppetlabs-training-bootstrap/modules:/opt/puppetlabs/puppet/modules --verbose /usr/src/puppetlabs-training-bootstrap/manifests/#{args{:role}}.pp")
 end
 
 desc "Post build cleanup tasks"

--- a/Rakefile
+++ b/Rakefile
@@ -155,7 +155,7 @@ task :lms_pre do
 end
 
 desc "Apply bootstrap manifest"
-task :build [:arg1] do |role|
+task :build, [:arg1] do |role|
  cputs "Installing R10k"
  system('PATH=$PATH:/opt/puppetlabs/puppet/bin:/usr/local/bin gem install r10k -v 1.5.1 --no-RI --no-RDOC')
  Dir.chdir('/usr/src/puppetlabs-training-bootstrap') do

--- a/Rakefile
+++ b/Rakefile
@@ -162,8 +162,8 @@ task :build, [:role] do |t,args|
   cputs "Running r10k Puppetfile install"
   system('PATH=$PATH:/opt/puppetlabs/puppet/bin:/usr/local/bin r10k puppetfile install')
  end
- cputs "Running puppet apply on #{args{:role}}.pp"
- system("PATH=$PATH:/opt/puppetlabs/puppet/bin puppet apply --modulepath=/usr/src/puppetlabs-training-bootstrap/modules:/opt/puppetlabs/puppet/modules --verbose /usr/src/puppetlabs-training-bootstrap/manifests/#{args{:role}}.pp")
+ cputs "Running puppet apply on #{args[:role]}.pp"
+ system("PATH=$PATH:/opt/puppetlabs/puppet/bin puppet apply --modulepath=/usr/src/puppetlabs-training-bootstrap/modules:/opt/puppetlabs/puppet/modules --verbose /usr/src/puppetlabs-training-bootstrap/manifests/#{args[:role]}.pp")
 end
 
 desc "Post build cleanup tasks"

--- a/Rakefile
+++ b/Rakefile
@@ -199,6 +199,15 @@ end
 desc "Full Learning VM Build"
 task :learning do
   cputs "Building Learning VM"
+  Rake::Task["learning_pre"].execute
+  Rake::Task["install_pe"].execute
+  Rake::Task["build"].invoke("learning")
+  Rake::Task["post"].execute
+end
+
+desc "Learning VM on Master"
+task :learning_master do
+  cputs "Building Learning VM from Master VM"
   Rake::Task["build"].invoke("learning")
   Rake::Task["post"].execute
 end

--- a/manifests/learning.pp
+++ b/manifests/learning.pp
@@ -1,0 +1,1 @@
+include bootstrap::role::learning

--- a/manifests/lms.pp
+++ b/manifests/lms.pp
@@ -1,0 +1,1 @@
+include bootstrap::role::lms

--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -1,0 +1,1 @@
+include bootstrap::role::master

--- a/manifests/student.pp
+++ b/manifests/student.pp
@@ -1,0 +1,1 @@
+include bootstrap::role::student

--- a/manifests/training.pp
+++ b/manifests/training.pp
@@ -1,0 +1,1 @@
+include bootstrap::role::training

--- a/packer/educationbase.json
+++ b/packer/educationbase.json
@@ -13,7 +13,7 @@
       "iso_checksum_type": "sha1",
       "iso_url": "{{ user `iso_url` }}",
       "output_directory": "output/{{ user `vm_type` }}-base-vmware",
-      "shutdown_command": "sudo shutdown now",
+      "shutdown_command": "sudo shutdown -P now",
       "ssh_username": "training",
       "ssh_password": "training",
       "skip_compaction": "true",

--- a/packer/educationbuild.json
+++ b/packer/educationbuild.json
@@ -1,12 +1,13 @@
 {
   "builders": [
     {
+      "vm_name": "{{ user `vm_type`}}",
       "type": "vmware-vmx",
       "source_path": "output/{{ user `vm_type` }}-base-vmware/{{ user `vm_type` }}-base.vmx",
       "ssh_username": "training",
       "ssh_password": "training",
       "skip_compaction": "true",
-      "shutdown_command": "sudo shutdown now",
+      "shutdown_command": "{{user `shutdown_command`}}",
       "output_directory": "output/{{ user `vm_type`}}-vmware/",
       "ssh_pty": "true"
     }

--- a/packer/learning.json
+++ b/packer/learning.json
@@ -1,4 +1,5 @@
 {
+  "shutdown_command":"",
   "vm_type": "learning",
   "guest_os_type": "rhel7-64",
   "os_name": "CentOS-7",

--- a/packer/master.json
+++ b/packer/master.json
@@ -1,4 +1,5 @@
 {
+  "shutdown_command":"sudo shutdown -P now",
   "vm_type": "master",
   "guest_os_type": "rhel7-64",
   "os_name": "CentOS-7",

--- a/packer/scripts/base.sh
+++ b/packer/scripts/base.sh
@@ -9,4 +9,4 @@ sudo sed -i "s/^\(.*env_keep = \"\)/\1PATH /" /etc/sudoers
 sudo yum install -y nfs-utils 
 
 # Install devlopment tools
-sudo yum group install -y "Development Tools"
+sudo yum groupinstall -y "Development Tools"

--- a/packer/training.json
+++ b/packer/training.json
@@ -1,4 +1,5 @@
 {
+  "shutdown_command": "sudo shutdown -P now",
   "vm_type": "training",
   "guest_os_type": "centos-64",
   "hostname": "training",


### PR DESCRIPTION
This goes with some changes to the bootstrap/learning modules to simplify and clean up.

Primarily it decouples the build from the hostname so that we could eventually build a Learning VM with the hostname "master.puppetlabs.vm".

It also adds a rake task for installing the learning VM on top of an existing master VM, which needs some more iteration.

Finally, it fixes the shutdown issue the learning VM build was having.